### PR TITLE
Add "Read the Docs" to the list

### DIFF
--- a/_lists/apps
+++ b/_lists/apps
@@ -27,3 +27,4 @@ geary@floss.social
 k9mail@fosstodon.org
 heroiclauncher@mastodon.social
 lutris@fosstodon.org
+readthedocs@fosstodon.org


### PR DESCRIPTION
Hi 👋🏼 . I'm adding Read the Docs to the list. Its account hosted as fosstodon: https://fosstodon.org/@readthedocs

Let me know if this PR is correct or I should do any modification.